### PR TITLE
Use proper error handling using error-chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ os:
 before_script:
   - |
       pip install 'travis-cargo<0.2' --user &&
-      export PATH=$HOME/.local/bin:$PATH
+      export PATH=$HOME/.local/bin:$HOME/Library/Python/2.7/bin:$PATH
 
 # the main build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_script:
   - |
       pip install 'travis-cargo<0.2' --user &&
       export PATH=$HOME/.local/bin:$HOME/Library/Python/2.7/bin:$PATH
+  - export LDFLAGS='-L/usr/local/opt/openssl/lib' CPPFLAGS='-I/usr/local/opt/openssl/include' PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'
+
 
 # the main build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,7 @@ after_success:
   # measure code coverage and upload to coveralls.io (the verify
   # argument mitigates kcov crashes due to malformed debuginfo, at the
   # cost of some speed <https://github.com/huonw/travis-cargo/issues/12>)
-  # - travis-cargo coveralls --no-sudo --verify
   # https://github.com/huonw/travis-cargo/issues/58
   # See https://github.com/ujh/iomrascalai/blob/master/.travis.yml
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --no-sudo --verify; fi
+  # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --no-sudo --verify; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/gitlab_api-*; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,14 @@ os:
 
 # load travis-cargo
 before_script:
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      export PATH=$HOME/.local/bin:$HOME/Library/Python/2.7/bin:$PATH
-  - export LDFLAGS='-L/usr/local/opt/openssl/lib' CPPFLAGS='-I/usr/local/opt/openssl/include' PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'
-  - brew update && brew install openssl
+  - pip install 'travis-cargo<0.2' --user
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$HOME/.local/bin:$PATH; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export PATH=$HOME/Library/Python/2.7/bin:$PATH; fi
+  # Install OpenSSL through homebrew
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew update && brew install openssl; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export LDFLAGS='-L/usr/local/opt/openssl/lib'; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export CPPFLAGS='-I/usr/local/opt/openssl/include';; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'; fi
 
 
 # the main build

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ after_success:
   # cost of some speed <https://github.com/huonw/travis-cargo/issues/12>)
   # https://github.com/huonw/travis-cargo/issues/58
   # See https://github.com/ujh/iomrascalai/blob/master/.travis.yml
-  # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --no-sudo --verify; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/gitlab_api-*; fi
+  # - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then travis-cargo coveralls --no-sudo --verify; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/gitlab_api-*; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ after_success:
   # cost of some speed <https://github.com/huonw/travis-cargo/issues/12>)
   # https://github.com/huonw/travis-cargo/issues/58
   # See https://github.com/ujh/iomrascalai/blob/master/.travis.yml
-  # - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then travis-cargo coveralls --no-sudo --verify; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then travis-cargo coveralls --no-sudo --verify; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/gitlab_api-*; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   # Install OpenSSL through homebrew
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew update && brew install openssl; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export LDFLAGS='-L/usr/local/opt/openssl/lib'; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export CPPFLAGS='-I/usr/local/opt/openssl/include';; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export CPPFLAGS='-I/usr/local/opt/openssl/include'; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'; fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_script:
       pip install 'travis-cargo<0.2' --user &&
       export PATH=$HOME/.local/bin:$HOME/Library/Python/2.7/bin:$PATH
   - export LDFLAGS='-L/usr/local/opt/openssl/lib' CPPFLAGS='-I/usr/local/opt/openssl/include' PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'
+  - brew update && brew install openssl
 
 
 # the main build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export PATH=$HOME/Library/Python/2.7/bin:$PATH; fi
   # Install OpenSSL through homebrew
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew update && brew install openssl; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export LDFLAGS='-L/usr/local/opt/openssl/lib'; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export CPPFLAGS='-I/usr/local/opt/openssl/include'; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then export DEP_OPENSSL_INCLUDE=`brew --prefix openssl`/include; fi
 
 
 # the main build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.3"
 
 [dependencies]
 log = "0.3"
+error-chain = "0.7.1"
 serde = "0.8"
 serde_derive = { version = "0.8", optional = true }
 serde_json = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitlab-api"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Nicolas Bigaouette <nbigaouette@gmail.com>"]
 description = "Wrapper for GitLab API v3"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "0.3"
 [dependencies]
 log = "0.3"
 error-chain = "0.7.1"
+url = "1.2.3"
 serde = "0.8"
 serde_derive = { version = "0.8", optional = true }
 serde_json = "0.8"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ The (v3) API is quite long, so the parts I need will be implemented first.
     * hooks;
     * starred;
     * visible;
-* Error handling. This crate `unwraps()` results instead of handling them. This was done until the API stabilized.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The (v3) API is quite long, so the parts I need will be implemented first.
 
 ```
 [dependencies]
-gitlab-api = "0.3.0"
+gitlab-api = "0.4.0"
 ```
 
 This crate uses a builder pattern to add filters to a query. Once the query is built, `list()` will commit it by contacting the GitLab server and performing the request.

--- a/examples/list_groups.rs
+++ b/examples/list_groups.rs
@@ -5,8 +5,28 @@ use std::env;
 extern crate log;
 extern crate env_logger;
 
+use gitlab::errors::*;
+
 
 fn main() {
+    if let Err(ref e) = run() {
+        println!("error: {}", e);
+
+        for e in e.iter().skip(1) {
+            println!("caused by: {}", e);
+        }
+
+        // The backtrace is not always generated. Try to run this example
+        // with `RUST_BACKTRACE=1`.
+        if let Some(backtrace) = e.backtrace() {
+            println!("backtrace: {:?}", backtrace);
+        }
+
+        ::std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     env_logger::init().unwrap();
     info!("starting up");
 
@@ -39,18 +59,20 @@ fn main() {
     });
     println!("gl: {:?}", gl);
 
-    let groups = gl.groups().list();
+    let groups = gl.groups().list().chain_err(|| "cannot get groups")?;
     println!("groups: {:?}", groups);
 
-    let groups = gl.groups().details(gitlab::groups::ListingId::Id(21)).list();
+    let groups = gl.groups().details(gitlab::groups::ListingId::Id(21)).list().chain_err(|| "cannot get groups")?;
     println!("groups: {:?}", groups);
 
     // let groups = gl.groups(gitlab::groups::Listing::new().skip_groups(vec![1, 2, 3]).clone());
     // println!("groups: {:?}", groups);
     //
-    let owned_groups = gl.groups().owned().list();
+    let owned_groups = gl.groups().owned().list().chain_err(|| "cannot get groups")?;
     println!("owned_groups: {:?}", owned_groups);
 
-    let projects_groups = gl.groups().projects(21).list();
+    let projects_groups = gl.groups().projects(21).list().chain_err(|| "cannot get groups")?;
     println!("projects_groups: {:?}", projects_groups);
+
+    Ok(())
 }

--- a/examples/list_groups.rs
+++ b/examples/list_groups.rs
@@ -49,8 +49,8 @@ fn run() -> Result<()> {
         }
     };
 
-    let mut gl = gitlab::GitLab::new(&hostname, &token);
-    // let mut gl = gitlab::GitLab::new(&hostname, &token).scheme("http").port(80);
+    let mut gl = gitlab::GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?;
+    // let mut gl = gitlab::GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?.scheme("http").port(80);
     // gl = gl.scheme("http").port(80);
 
     gl.set_pagination(gitlab::Pagination {

--- a/examples/list_groups.rs
+++ b/examples/list_groups.rs
@@ -62,7 +62,10 @@ fn run() -> Result<()> {
     let groups = gl.groups().list().chain_err(|| "cannot get groups")?;
     println!("groups: {:?}", groups);
 
-    let groups = gl.groups().details(gitlab::groups::ListingId::Id(21)).list().chain_err(|| "cannot get groups")?;
+    let groups = gl.groups()
+        .details(gitlab::groups::ListingId::Id(21))
+        .list()
+        .chain_err(|| "cannot get groups")?;
     println!("groups: {:?}", groups);
 
     // let groups = gl.groups(gitlab::groups::Listing::new().skip_groups(vec![1, 2, 3]).clone());

--- a/examples/list_issues.rs
+++ b/examples/list_issues.rs
@@ -9,8 +9,28 @@ use gitlab::GitLab;
 // use gitlab::Pagination;
 use gitlab::issues;
 
+use gitlab::errors::*;
+
 
 fn main() {
+    if let Err(ref e) = run() {
+        println!("error: {}", e);
+
+        for e in e.iter().skip(1) {
+            println!("caused by: {}", e);
+        }
+
+        // The backtrace is not always generated. Try to run this example
+        // with `RUST_BACKTRACE=1`.
+        if let Some(backtrace) = e.backtrace() {
+            println!("backtrace: {:?}", backtrace);
+        }
+
+        ::std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     env_logger::init().unwrap();
     info!("starting up");
 
@@ -37,21 +57,23 @@ fn main() {
     // let gl = GitLab::new(&hostname, &token).scheme("http").port(80);
     // let gl = gl.scheme("http").port(80);
 
-    let issues = gl.issues().list();
+    let issues = gl.issues().list().chain_err(|| "cannot get issues")?;
     println!("issues: {:?}", issues);
 
-    let opened_issues = gl.issues().state(issues::State::Opened).list();
+    let opened_issues = gl.issues().state(issues::State::Opened).list().chain_err(|| "cannot get issues")?;
     println!("opened_issues: {:?}", opened_issues);
 
-    let closed_issues = gl.issues().state(issues::State::Closed).list();
+    let closed_issues = gl.issues().state(issues::State::Closed).list().chain_err(|| "cannot get issues")?;
     println!("closed_issues: {:?}", closed_issues);
 
-    let issue = gl.issues().single(142, 739).list();
+    let issue = gl.issues().single(142, 739).list().chain_err(|| "cannot get issues")?;
     println!("issue: {:?}", issue);
 
-    let group_issues = gl.issues().group(21).state(issues::State::Closed).list();
+    let group_issues = gl.issues().group(21).state(issues::State::Closed).list().chain_err(|| "cannot get issues")?;
     println!("group_issues: {:?}", group_issues);
 
-    let project_issues = gl.issues().project(142).state(issues::State::Opened).list();
+    let project_issues = gl.issues().project(142).state(issues::State::Opened).list().chain_err(|| "cannot get issues")?;
     println!("project_issues: {:?}", project_issues);
+
+    Ok(())
 }

--- a/examples/list_issues.rs
+++ b/examples/list_issues.rs
@@ -53,8 +53,8 @@ fn run() -> Result<()> {
         }
     };
 
-    let gl = GitLab::new(&hostname, &token);
-    // let gl = GitLab::new(&hostname, &token).scheme("http").port(80);
+    let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?;
+    // let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?.scheme("http").port(80);
     // let gl = gl.scheme("http").port(80);
 
     let issues = gl.issues().list().chain_err(|| "cannot get issues")?;

--- a/examples/list_issues.rs
+++ b/examples/list_issues.rs
@@ -60,19 +60,29 @@ fn run() -> Result<()> {
     let issues = gl.issues().list().chain_err(|| "cannot get issues")?;
     println!("issues: {:?}", issues);
 
-    let opened_issues = gl.issues().state(issues::State::Opened).list().chain_err(|| "cannot get issues")?;
+    let opened_issues =
+        gl.issues().state(issues::State::Opened).list().chain_err(|| "cannot get issues")?;
     println!("opened_issues: {:?}", opened_issues);
 
-    let closed_issues = gl.issues().state(issues::State::Closed).list().chain_err(|| "cannot get issues")?;
+    let closed_issues =
+        gl.issues().state(issues::State::Closed).list().chain_err(|| "cannot get issues")?;
     println!("closed_issues: {:?}", closed_issues);
 
     let issue = gl.issues().single(142, 739).list().chain_err(|| "cannot get issues")?;
     println!("issue: {:?}", issue);
 
-    let group_issues = gl.issues().group(21).state(issues::State::Closed).list().chain_err(|| "cannot get issues")?;
+    let group_issues = gl.issues()
+        .group(21)
+        .state(issues::State::Closed)
+        .list()
+        .chain_err(|| "cannot get issues")?;
     println!("group_issues: {:?}", group_issues);
 
-    let project_issues = gl.issues().project(142).state(issues::State::Opened).list().chain_err(|| "cannot get issues")?;
+    let project_issues = gl.issues()
+        .project(142)
+        .state(issues::State::Opened)
+        .list()
+        .chain_err(|| "cannot get issues")?;
     println!("project_issues: {:?}", project_issues);
 
     Ok(())

--- a/examples/list_merge_requests.rs
+++ b/examples/list_merge_requests.rs
@@ -59,13 +59,20 @@ fn run() -> Result<()> {
     let merge_requests_ids = vec![409, 410];
     let merge_requests_iids = vec![3, 4];
 
-    let merge_requests = gl.merge_requests(project_id).list().chain_err(|| "cannot get merge request")?;
+    let merge_requests =
+        gl.merge_requests(project_id).list().chain_err(|| "cannot get merge request")?;
     println!("merge_requests: {:?}", merge_requests);
 
-    let merge_request = gl.merge_requests(project_id).single(merge_requests_ids[0]).list().chain_err(|| "cannot get merge request")?;
+    let merge_request = gl.merge_requests(project_id)
+        .single(merge_requests_ids[0])
+        .list()
+        .chain_err(|| "cannot get merge request")?;
     println!("merge_request: {:?}", merge_request);
 
-    let merge_requests = gl.merge_requests(project_id).iid(vec![merge_requests_iids[0]]).list().chain_err(|| "cannot get merge request")?;
+    let merge_requests = gl.merge_requests(project_id)
+        .iid(vec![merge_requests_iids[0]])
+        .list()
+        .chain_err(|| "cannot get merge request")?;
     println!("merge_requests: {:?}", merge_requests);
 
     // let merge_requests = gl.merge_requests(project_id).iid(merge_requests_iids).list().chain_err(|| "cannot get merge request")?;

--- a/examples/list_merge_requests.rs
+++ b/examples/list_merge_requests.rs
@@ -51,8 +51,8 @@ fn run() -> Result<()> {
         }
     };
 
-    let gl = GitLab::new(&hostname, &token);
-    // let gl = GitLab::new(&hostname, &token).scheme("http").port(80);
+    let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?;
+    // let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?.scheme("http").port(80);
     // let gl = gl.scheme("http").port(80);
 
     let project_id = 142;

--- a/examples/list_merge_requests.rs
+++ b/examples/list_merge_requests.rs
@@ -7,8 +7,28 @@ extern crate env_logger;
 
 use gitlab::GitLab;
 
+use gitlab::errors::*;
+
 
 fn main() {
+    if let Err(ref e) = run() {
+        println!("error: {}", e);
+
+        for e in e.iter().skip(1) {
+            println!("caused by: {}", e);
+        }
+
+        // The backtrace is not always generated. Try to run this example
+        // with `RUST_BACKTRACE=1`.
+        if let Some(backtrace) = e.backtrace() {
+            println!("backtrace: {:?}", backtrace);
+        }
+
+        ::std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     env_logger::init().unwrap();
     info!("starting up");
 
@@ -39,15 +59,17 @@ fn main() {
     let merge_requests_ids = vec![409, 410];
     let merge_requests_iids = vec![3, 4];
 
-    let merge_requests = gl.merge_requests(project_id).list();
+    let merge_requests = gl.merge_requests(project_id).list().chain_err(|| "cannot get merge request")?;
     println!("merge_requests: {:?}", merge_requests);
 
-    let merge_request = gl.merge_requests(project_id).single(merge_requests_ids[0]).list();
+    let merge_request = gl.merge_requests(project_id).single(merge_requests_ids[0]).list().chain_err(|| "cannot get merge request")?;
     println!("merge_request: {:?}", merge_request);
 
-    let merge_requests = gl.merge_requests(project_id).iid(vec![merge_requests_iids[0]]).list();
+    let merge_requests = gl.merge_requests(project_id).iid(vec![merge_requests_iids[0]]).list().chain_err(|| "cannot get merge request")?;
     println!("merge_requests: {:?}", merge_requests);
 
-    // let merge_requests = gl.merge_requests(project_id).iid(merge_requests_iids).list();
+    // let merge_requests = gl.merge_requests(project_id).iid(merge_requests_iids).list().chain_err(|| "cannot get merge request")?;
     // println!("merge_requests: {:?}", merge_requests);
+
+    Ok(())
 }

--- a/examples/list_projects.rs
+++ b/examples/list_projects.rs
@@ -53,8 +53,8 @@ fn run() -> Result<()> {
         }
     };
 
-    let gl = GitLab::new(&hostname, &token);
-    // let gl = GitLab::new(&hostname, &token).scheme("http").port(80);
+    let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?;
+    // let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?.scheme("http").port(80);
     // let gl = gl.scheme("http").port(80);
 
     let projects = gl.projects().list().chain_err(|| "cannot get projects")?;

--- a/examples/list_projects.rs
+++ b/examples/list_projects.rs
@@ -63,10 +63,15 @@ fn run() -> Result<()> {
     let projects = gl.projects().archived(false).list().chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
-    let projects = gl.projects().owned().archived(false).list().chain_err(|| "cannot get projects")?;
+    let projects =
+        gl.projects().owned().archived(false).list().chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
-    let projects = gl.projects().all().order_by(gitlab::projects::ListingOrderBy::Name).list().chain_err(|| "cannot get projects")?;
+    let projects = gl.projects()
+        .all()
+        .order_by(gitlab::projects::ListingOrderBy::Name)
+        .list()
+        .chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
     Ok(())

--- a/examples/list_projects.rs
+++ b/examples/list_projects.rs
@@ -9,8 +9,28 @@ extern crate env_logger;
 use gitlab::GitLab;
 // use gitlab::Pagination;
 
+use gitlab::errors::*;
+
 
 fn main() {
+    if let Err(ref e) = run() {
+        println!("error: {}", e);
+
+        for e in e.iter().skip(1) {
+            println!("caused by: {}", e);
+        }
+
+        // The backtrace is not always generated. Try to run this example
+        // with `RUST_BACKTRACE=1`.
+        if let Some(backtrace) = e.backtrace() {
+            println!("backtrace: {:?}", backtrace);
+        }
+
+        ::std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     env_logger::init().unwrap();
     info!("starting up");
 
@@ -37,16 +57,17 @@ fn main() {
     // let gl = GitLab::new(&hostname, &token).scheme("http").port(80);
     // let gl = gl.scheme("http").port(80);
 
-    let projects = gl.projects().list();
+    let projects = gl.projects().list().chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
-    let projects = gl.projects().archived(false).list();
+    let projects = gl.projects().archived(false).list().chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
-    let projects = gl.projects().owned().archived(false).list();
+    let projects = gl.projects().owned().archived(false).list().chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
-    let projects = gl.projects().all().order_by(gitlab::projects::ListingOrderBy::Name).list();
+    let projects = gl.projects().all().order_by(gitlab::projects::ListingOrderBy::Name).list().chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
+    Ok(())
 }

--- a/examples/version.rs
+++ b/examples/version.rs
@@ -52,7 +52,7 @@ fn run() -> Result<()> {
         }
     };
 
-    let gl = GitLab::new(&hostname, &token);
+    let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?;
     // let gl = GitLab::new(&hostname, &token).scheme("http").port(80);
     // let gl = gl.scheme("http").port(80);
     let version = gl.version().chain_err(|| "cannot get version")?;

--- a/examples/version.rs
+++ b/examples/version.rs
@@ -55,8 +55,8 @@ fn run() -> Result<()> {
     let gl = GitLab::new(&hostname, &token);
     // let gl = GitLab::new(&hostname, &token).scheme("http").port(80);
     // let gl = gl.scheme("http").port(80);
+    let version = gl.version().chain_err(|| "cannot get version")?;
 
-    let version = gl.version();
     println!("version: {:?}", version);
 
     Ok(())

--- a/examples/version.rs
+++ b/examples/version.rs
@@ -8,8 +8,28 @@ extern crate env_logger;
 
 use gitlab::GitLab;
 
+use gitlab::errors::*;
+
 
 fn main() {
+    if let Err(ref e) = run() {
+        println!("error: {}", e);
+
+        for e in e.iter().skip(1) {
+            println!("caused by: {}", e);
+        }
+
+        // The backtrace is not always generated. Try to run this example
+        // with `RUST_BACKTRACE=1`.
+        if let Some(backtrace) = e.backtrace() {
+            println!("backtrace: {:?}", backtrace);
+        }
+
+        ::std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     env_logger::init().unwrap();
     info!("starting up");
 
@@ -38,4 +58,6 @@ fn main() {
 
     let version = gl.version();
     println!("version: {:?}", version);
+
+    Ok(())
 }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -48,13 +48,15 @@ impl fmt::Debug for GitLab {
 
 fn validate_url(scheme: &str, domain: &str, port: u16) -> Result<url::Url> {
 
-    let index = match domain.find(".") {
-        None => bail!(format!("invalid domain: '{}' should contain at least one dot", domain)),
-        Some(index) => index
+    match domain.find(".") {
+        None => { /* pass */ },
+        Some(index) => {
+            if index == 0 {
+                bail!(format!("invalid domain: '{}' cannot start with a dot", domain));
+            }
+        },
     };
-    if index == 0 {
-        bail!(format!("invalid domain: '{}' cannot start with a dot", domain));
-    }
+
     if domain.ends_with(".") {
         bail!(format!("invalid domain: '{}' cannot end with a dot", domain));
     }
@@ -284,23 +286,20 @@ mod tests {
 
         let gl = GitLab::new_insecure("gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
         verify_ok(&gl);
-    }
 
-    #[test]
-    fn new_invalid_url_0() {
-        let gl = GitLab::new("", "XXXXXXXXXXXXXXXXXXXX");
-        verify_err(&gl);
+        let gl = GitLab::new("localhost", "XXXXXXXXXXXXXXXXXXXX");
+        verify_ok(&gl);
 
-        let gl = GitLab::new_insecure("", "XXXXXXXXXXXXXXXXXXXX");
-        verify_err(&gl);
+        let gl = GitLab::new_insecure("localhost", "XXXXXXXXXXXXXXXXXXXX");
+        verify_ok(&gl);
     }
 
     #[test]
     fn new_invalid_url_1() {
-        let gl = GitLab::new("gitlab", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = GitLab::new("", "XXXXXXXXXXXXXXXXXXXX");
         verify_err(&gl);
 
-        let gl = GitLab::new_insecure("gitlab", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = GitLab::new_insecure("", "XXXXXXXXXXXXXXXXXXXX");
         verify_err(&gl);
     }
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -54,7 +54,7 @@ impl fmt::Debug for GitLab {
 impl GitLab {
     pub fn _new(scheme: &str, domain: &str, port: u16, private_token: &str) -> GitLab {
         let mut url = url::Url::parse(&format!("{}://{}/api/v{}/", scheme, domain, API_VERSION))
-                                .unwrap();
+            .unwrap();
         url.set_port(Some(port)).unwrap();
         GitLab {
             scheme: scheme.to_string(),
@@ -164,7 +164,8 @@ impl GitLab {
             bail!(format!("status code ({}) not Ok()", res.status));
         }
 
-        serde_json::from_str(body.as_str()).chain_err(|| format!("cannot build Rust struct from JSON data: {}", body))
+        serde_json::from_str(body.as_str())
+            .chain_err(|| format!("cannot build Rust struct from JSON data: {}", body))
     }
 
     pub fn version(&self) -> Result<::Version> {

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -27,9 +27,6 @@ pub struct Pagination {
 
 #[derive(Default)]
 pub struct GitLab {
-    scheme: String,
-    domain: String,
-    port: u16,
     url: Option<url::Url>,
     private_token: String,
     pagination: Option<Pagination>,
@@ -43,9 +40,9 @@ impl fmt::Debug for GitLab {
         write!(f,
                "GitLab {{ scheme: {}, domain: {}, port: {}, private_token: XXXXXXXXXXXXXXXXXXXX, \
                 pagination: {:?} }}",
-               self.scheme,
-               self.domain,
-               self.port,
+               self.url.scheme(),
+               self.url.domain(),
+               self.url.port(),
                self.pagination)
     }
 }
@@ -57,9 +54,6 @@ impl GitLab {
             .unwrap();
         url.set_port(Some(port)).unwrap();
         GitLab {
-            scheme: scheme.to_string(),
-            domain: domain.to_string(),
-            port: port,
             url: Some(url),
             private_token: private_token.to_string(),
             pagination: None,
@@ -86,13 +80,11 @@ impl GitLab {
     }
 
     pub fn port(mut self, port: u16) -> Self {
-        self.port = port;
         self.url.as_mut().map(|url| url.set_port(Some(port)));
         self
     }
 
     pub fn scheme(mut self, scheme: &str) -> Self {
-        self.scheme = scheme.to_string();
         self.url.as_mut().map(|url| url.set_scheme(scheme));
         self
     }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -226,11 +226,152 @@ impl GitLab {
 }
 
 
-// #[cfg(test)]
-// mod tests {
-//
-// #[test]
-// fn it_works() {
-// }
-// }
-//
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+    use gitlab::*;
+    use errors::*;
+
+    fn verify_ok<T>(result: &Result<T>) {
+        if let &Err(ref e) = result {
+            println!("error: {}", e);
+
+            for e in e.iter().skip(1) {
+                println!("caused by: {}", e);
+            }
+
+            // The backtrace is not always generated. Try to run this example
+            // with `RUST_BACKTRACE=1`.
+            if let Some(backtrace) = e.backtrace() {
+                println!("backtrace: {:?}", backtrace);
+            }
+        }
+        assert!(result.is_ok());
+    }
+
+    fn verify_err<T>(result: &Result<T>)
+        where T: fmt::Debug
+    {
+        match result {
+            &Err(_) => { /* pass */ },
+            &Ok(ref t) => {
+                panic!(format!("Expected an Err(), got an Ok(t), with t: {:?}", t));
+            }
+        }
+    }
+
+
+    #[test]
+    fn new_valid() {
+        let gl = GitLab::new("gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_ok(&gl);
+
+        let gl = GitLab::new_insecure("gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_ok(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_0() {
+        let gl = GitLab::new("", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_1() {
+        let gl = GitLab::new("gitlab", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("gitlab", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_2() {
+        let gl = GitLab::new("gitla/b.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("gitla/b.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_3() {
+        let gl = GitLab::new("/gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("/gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_4() {
+        let gl = GitLab::new("http:/gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("http:/gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_5() {
+        let gl = GitLab::new("http:///gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("http:///gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_6() {
+        let gl = GitLab::new(".gitlab", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure(".gitlab", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_7() {
+        let gl = GitLab::new(".gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure(".gitlab.com", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_8() {
+        let gl = GitLab::new("gitlab.", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("gitlab.", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_url_10() {
+        let gl = GitLab::new("gitlab.com.", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+
+        let gl = GitLab::new_insecure("gitlab.com.", "XXXXXXXXXXXXXXXXXXXX");
+        verify_err(&gl);
+    }
+
+    #[test]
+    fn new_invalid_token() {
+        let gl = GitLab::new("gitlab.com", "");
+        assert!(gl.is_err());
+
+        let gl = GitLab::new("gitlab.com", "X");
+        assert!(gl.is_err());
+
+        let gl = GitLab::new("gitlab.com", "XXXXXXXXXXXXXXXXXXX");
+        assert!(gl.is_err());
+
+        let gl = GitLab::new("gitlab.com", "XXXXXXXXXXXXXXXXXXXXX");
+        assert!(gl.is_err());
+    }
+}

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -159,6 +159,22 @@ impl GitLab {
     //     self.client.get(&url).header(hyper::header::Connection::close()).send()
     // }
 
+
+    /// Set pagination information
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gitlab_api::{GitLab, Pagination};
+    ///
+    /// let expected_url = "https://gitlab.example.com\
+    ///                     /api/v3/groups?order_by=path&\
+    ///                     private_token=XXXXXXXXXXXXXXXXXXXX&page=2&per_page=5";
+    ///
+    /// let mut gl = GitLab::new("gitlab.example.com", "XXXXXXXXXXXXXXXXXXXX").unwrap();
+    /// gl.set_pagination(Pagination {page: 2, per_page: 5});
+    /// assert_eq!(gl.build_url("groups?order_by=path").unwrap(), expected_url);
+    /// ```
     pub fn set_pagination(&mut self, pagination: Pagination) {
         self.pagination = Some(pagination);
     }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -40,8 +40,8 @@ impl fmt::Debug for GitLab {
                "GitLab {{ scheme: {}, domain: {}, port: {}, private_token: XXXXXXXXXXXXXXXXXXXX, \
                 pagination: {:?} }}",
                self.url.scheme(),
-               self.url.domain().expect("bad hostname provided"),
-               self.url.port().expect("bad port provided"),
+               self.url.domain().unwrap_or("bad hostname provided"),
+               self.url.port().map(|port_u16| port_u16.to_string()).unwrap_or("no port provided".to_string()),
                self.pagination)
     }
 }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -113,15 +113,20 @@ impl GitLab {
     ///
     /// assert_eq!(gl.build_url("groups?order_by=path"), expected_url);
     /// ```
-    pub fn build_url(&self, query: &str) -> String {
-        let mut new_url = self.url.clone().unwrap().join(query).unwrap();
+    pub fn build_url(&self, query: &str) -> Result<String> {
+        let mut new_url =
+            self.url.clone().chain_err(|| "failure to clone URL").join(query).chain_err(|| {
+                format!("Failure to join query '{}' to url {}",
+                        query,
+                        self.url.as_str())
+            });
         new_url.query_pairs_mut().append_pair("private_token", &self.private_token);
         self.pagination.as_ref().map(|pagination| {
             new_url.query_pairs_mut().append_pair("page", &pagination.page.to_string());
             new_url.query_pairs_mut().append_pair("per_page", &pagination.per_page.to_string());
         });
 
-        new_url.into_string()
+        Ok(new_url.into_string())
     }
 
     // pub fn attempt_connection(&self) -> Result<hyper::client::Response, hyper::Error> {

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -153,7 +153,7 @@ impl GitLab {
         res.read_to_string(&mut body).unwrap();
         debug!("body:\n{:?}", body);
 
-        assert_eq!(res.status, hyper::status::StatusCode::Ok);
+        // assert_eq!(res.status, hyper::status::StatusCode::Ok);
 
         serde_json::from_str(body.as_str())
     }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -158,8 +158,8 @@ impl GitLab {
         serde_json::from_str(body.as_str())
     }
 
-    pub fn version(&self) -> ::Version {
-        self.get("version").unwrap()
+    pub fn version(&self) -> Result<::Version, serde_json::Error> {
+        self.get::<::Version>("version")
     }
 
     pub fn groups(&self) -> ::groups::GroupsLister {

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -10,8 +10,7 @@ use serde_json;
 
 // use Groups;
 
-// Import the ResultExt trait, giving the chain_err() method on Result
-use errors::ResultExt;
+use ::errors::*;
 
 
 pub const API_VERSION: u16 = 3;
@@ -134,34 +133,7 @@ impl GitLab {
         self.pagination = Some(pagination);
     }
 
-    pub fn get<T>(&self, query: &str) -> Result<T, serde_json::Error>
-        where T: serde::Deserialize
-    {
-        // FIXME: Properly handle any errors. Use chain_error crate.
-
-        let url = self.build_url(query);
-        info!("url: {:?}", url);
-
-        // Close connections after each GET.
-        let mut res: hyper::client::Response = self.client
-            .get(&url)
-            .header(hyper::header::Connection::close())
-            .send()
-            .unwrap();
-        info!("res.status: {:?}", res.status);
-        debug!("res.headers: {:?}", res.headers);
-        debug!("res.url: {:?}", res.url);
-
-        let mut body = String::new();
-        res.read_to_string(&mut body).unwrap();
-        debug!("body:\n{:?}", body);
-
-        // assert_eq!(res.status, hyper::status::StatusCode::Ok);
-
-        serde_json::from_str(body.as_str())
-    }
-
-    pub fn new_get<T>(&self, query: &str) -> ::errors::Result<T>
+    pub fn get<T>(&self, query: &str) -> Result<T>
         where T: serde::Deserialize
     {
         let url = self.build_url(query);
@@ -189,8 +161,8 @@ impl GitLab {
         serde_json::from_str(body.as_str()).chain_err(|| format!("cannot build Rust struct from JSON data: {}", body))
     }
 
-    pub fn version(&self) -> ::errors::Result<::Version> {
-        self.new_get("version").chain_err(|| "cannot query 'version'")
+    pub fn version(&self) -> Result<::Version> {
+        self.get("version").chain_err(|| "cannot query 'version'")
     }
 
     pub fn groups(&self) -> ::groups::GroupsLister {

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -145,7 +145,7 @@ impl GitLab {
             .get(&url)
             .header(hyper::header::Connection::close())
             .send()
-            .chain_err(|| format!("cannot send request {} to {:?}", query, self))?;
+            .chain_err(|| format!("cannot send request '{}' to {:?}", query, self))?;
         info!("res.status: {:?}", res.status);
         debug!("res.headers: {:?}", res.headers);
         debug!("res.url: {:?}", res.url);

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -131,9 +131,9 @@ impl GitLab {
     /// use gitlab_api::GitLab;
     ///
     /// let expected_url = "https://gitlab.example.com\
-    ///                     /api/v3/groups?order_by=path&private_token=XXXXXXXXXXXXX";
+    ///                     /api/v3/groups?order_by=path&private_token=XXXXXXXXXXXXXXXXXXXX";
     ///
-    /// let gl = GitLab::new("gitlab.example.com", "XXXXXXXXXXXXX").unwrap();
+    /// let gl = GitLab::new("gitlab.example.com", "XXXXXXXXXXXXXXXXXXXX").unwrap();
     ///
     /// assert_eq!(gl.build_url("groups?order_by=path").unwrap(), expected_url);
     /// ```

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -61,8 +61,7 @@ impl GitLab {
                 Ok(proxy) => {
                     let proxy: Vec<&str> = proxy.trim_left_matches("http://").split(':').collect();
                     let hostname = proxy[0].to_string();
-                    // let port = proxy[1].parse().chain_err(|| format!("failure to set port to {}", port))?;
-                    let port = proxy[1].parse().unwrap();
+                    let port = proxy[1].parse().chain_err(|| format!("failure to set port to {}", port))?;
 
                     hyper::Client::with_http_proxy(hostname, port)
                 }

--- a/src/groups/details.rs
+++ b/src/groups/details.rs
@@ -18,10 +18,10 @@
 //!
 
 
-use serde_json;
-
 use BuildQuery;
 use Group;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -38,13 +38,11 @@ impl<'a> GroupLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a group.
-    pub fn list(&self) -> Group {
+    pub fn list(&self) -> Result<Group> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let group: Result<Group, serde_json::Error> = self.gl.get(&query);
-
-        group.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/groups/details.rs
+++ b/src/groups/details.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn build_query_default_i64() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}", TEST_GROUP_ID_I64);
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn build_query_default_str() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}", TEST_GROUP_ID_STRING.replace("/", "%2F"));

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -28,7 +28,6 @@
 //!
 
 
-use serde_json;
 // use serde_urlencoded;
 
 use BuildQuery;
@@ -37,6 +36,9 @@ use Groups;
 pub mod owned;
 pub mod projects;
 pub mod details;
+
+use ::errors::*;
+
 
 #[cfg(feature = "serde_derive")]
 include!("serde_types.in.rs");
@@ -110,13 +112,11 @@ impl<'a> GroupsLister<'a> {
 
 
     /// Commit the lister: Query GitLab and return a list of groups.
-    pub fn list(&self) -> Groups {
+    pub fn list(&self) -> Result<Groups> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let groups: Result<Groups, serde_json::Error> = self.gl.get(&query);
-
-        groups.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups";
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_skip_groups() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups?skip_groups[]=1&skip_groups[]=2&skip_groups[]=3";
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_all_available() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups?all_available=true";
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_search() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups?search=SearchPattern";
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_order_by_name() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups?order_by=name";
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_order_by_path() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups?order_by=path";
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups?sort=asc";
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_search_order_by_path() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups?search=SearchPattern&order_by=path";

--- a/src/groups/owned.rs
+++ b/src/groups/owned.rs
@@ -11,10 +11,10 @@
 //! ```
 
 
-use serde_json;
-
 use BuildQuery;
 use Groups;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -29,13 +29,11 @@ impl<'a> GroupsLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of groups.
-    pub fn list(&self) -> Groups {
+    pub fn list(&self) -> Result<Groups> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let groups: Result<Groups, serde_json::Error> = self.gl.get(&query);
-
-        groups.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/groups/owned.rs
+++ b/src/groups/owned.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn build_query_default_split0() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/owned";
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn build_query_default_split1() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/owned";
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/owned";

--- a/src/groups/projects.rs
+++ b/src/groups/projects.rs
@@ -24,13 +24,14 @@
 //!
 
 
-use serde_json;
 use serde_urlencoded;
 
 use BuildQuery;
 use Projects;
 
 use groups::ProjectsListerInternal;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -90,13 +91,11 @@ impl<'a> ProjectsLister<'a> {
 
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Projects {
+    pub fn list(&self) -> Result<Projects> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let projects: Result<Projects, serde_json::Error> = self.gl.get(&query);
-
-        projects.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/groups/projects.rs
+++ b/src/groups/projects.rs
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn build_query_default_split0() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects", TEST_PROJECT_ID);
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn build_query_default_split1() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects", TEST_PROJECT_ID);
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects", TEST_PROJECT_ID);
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn build_query_archived() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects?archived=true", TEST_PROJECT_ID);
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn build_query_visibility() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects?visibility=public", TEST_PROJECT_ID);
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects?order_by=id", TEST_PROJECT_ID);
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects?sort=asc", TEST_PROJECT_ID);
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn build_query_search() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects?search=SearchPattern", TEST_PROJECT_ID);
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn build_query_ci_enabled_first() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects?ci_enabled_first=true", TEST_PROJECT_ID);
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/projects?archived=true&ci_enabled_first=true",

--- a/src/issues/group.rs
+++ b/src/issues/group.rs
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("groups/{}/issues", TEST_PROJECT_ID);
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn build_query_state() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/123/issues?state=opened";
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn build_query_skip_groups() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/123/issues?labels=label1,label2,label3";
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/123/issues?order_by=created_at";
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/123/issues?sort=asc";
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/123/issues?order_by=created_at&sort=asc";

--- a/src/issues/group.rs
+++ b/src/issues/group.rs
@@ -28,12 +28,13 @@
 //!
 
 
-use serde_json;
 // use serde_urlencoded;
 
 use BuildQuery;
 use Issues;
 use issues::GroupIssuesListerInternal;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -88,13 +89,11 @@ impl<'a> IssuesLister<'a> {
 
 
     /// Commit the lister: Query GitLab and return a list of issues.
-    pub fn list(&self) -> Issues {
+    pub fn list(&self) -> Result<Issues> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let issues: Result<Issues, serde_json::Error> = self.gl.get(&query);
-
-        issues.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/issues/mod.rs
+++ b/src/issues/mod.rs
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "issues";
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn build_query_state() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "issues?state=opened";
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn build_query_skip_groups() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "issues?labels=label1,label2,label3";
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "issues?order_by=created_at";
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "issues?sort=asc";
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "issues?order_by=created_at&sort=asc";

--- a/src/issues/mod.rs
+++ b/src/issues/mod.rs
@@ -19,7 +19,6 @@
 //!
 
 
-use serde_json;
 // use serde_urlencoded;
 
 use BuildQuery;
@@ -28,6 +27,9 @@ use Issues;
 pub mod group;
 pub mod project;
 pub mod single;
+
+use ::errors::*;
+
 
 #[cfg(feature = "serde_derive")]
 include!("serde_types.in.rs");
@@ -95,13 +97,11 @@ impl<'a> IssuesLister<'a> {
 
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Issues {
+    pub fn list(&self) -> Result<Issues> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let projects: Result<Issues, serde_json::Error> = self.gl.get(&query);
-
-        projects.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/issues/project.rs
+++ b/src/issues/project.rs
@@ -30,12 +30,13 @@
 //!
 
 
-use serde_json;
 // use serde_urlencoded;
 
 use BuildQuery;
 use Issues;
 use issues::ProjectsIssuesListerInternal;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -96,13 +97,11 @@ impl<'a> IssuesLister<'a> {
 
 
     /// Commit the lister: Query GitLab and return a list of issues.
-    pub fn list(&self) -> Issues {
+    pub fn list(&self) -> Result<Issues> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let issues: Result<Issues, serde_json::Error> = self.gl.get(&query);
-
-        issues.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/issues/project.rs
+++ b/src/issues/project.rs
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/issues", TEST_PROJECT_ID);
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn build_query_state() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/issues?state=opened", TEST_PROJECT_ID);
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn build_query_skip_groups() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/issues?labels=label1,label2,label3",
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/issues?order_by=created_at", TEST_PROJECT_ID);
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/issues?sort=asc", TEST_PROJECT_ID);
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/issues?order_by=created_at&sort=asc",

--- a/src/issues/single.rs
+++ b/src/issues/single.rs
@@ -18,10 +18,10 @@
 //!
 
 
-use serde_json;
-
 use BuildQuery;
 use Issue;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -44,13 +44,11 @@ impl<'a> IssueLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Issue {
+    pub fn list(&self) -> Result<Issue> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let issue: Result<Issue, serde_json::Error> = self.gl.get(&query);
-
-        issue.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/issues/single.rs
+++ b/src/issues/single.rs
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/issues/{}", TEST_PROJECT_ID, TEST_ISSUE_ID);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-// Inspired by http://python-gitlab.readthedocs.io/en/stable/
-
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,18 @@ extern crate serde_urlencoded;
 #[macro_use]
 extern crate error_chain;
 
+// We'll put our errors in an `errors` module, and other modules in
+// this crate will `use errors::*;` to get access to everything
+// `error_chain!` creates.
+pub mod errors {
+    // Create the Error, ErrorKind, ResultExt, and Result types
+    error_chain! { }
+}
+
+use errors::*;
+
+
+
 #[cfg(feature = "serde_derive")]
 include!("serde_types.in.rs");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ extern crate error_chain;
 // `error_chain!` creates.
 pub mod errors {
     // Create the Error, ErrorKind, ResultExt, and Result types
-    error_chain! { }
+    error_chain!{}
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ extern crate serde;
 extern crate serde_json;
 extern crate serde_urlencoded;
 
+#[macro_use]
+extern crate error_chain;
+
 #[cfg(feature = "serde_derive")]
 include!("serde_types.in.rs");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ mod tests {
 
     // #[test]
     // fn unauthorized() {
-    //     let gl = GitLab::new("http", "gitlab.com", 80, "XXXXXXXXXXXXX");
+    //     let gl = GitLab::new("http", "gitlab.com", 80, "XXXXXXXXXXXXX").unwrap();
     //     println!("gl: {:?}", gl);
     //     assert_eq!(gl.attempt_connection().unwrap().status,
     //                hyper::status::StatusCode::Unauthorized);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ include!(concat!(env!("OUT_DIR"), "/serde_types.rs"));
 extern crate log;
 extern crate hyper;
 
+extern crate url;
+
 
 pub mod gitlab;
 pub mod groups;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,6 @@ pub mod errors {
     error_chain! { }
 }
 
-use errors::*;
-
-
 
 #[cfg(feature = "serde_derive")]
 include!("serde_types.in.rs");

--- a/src/merge_requests/mod.rs
+++ b/src/merge_requests/mod.rs
@@ -27,12 +27,13 @@
 //!
 
 
-use serde_json;
 // use serde_urlencoded;
 
 use BuildQuery;
 
 pub mod single;
+
+use ::errors::*;
 
 
 #[cfg(feature = "serde_derive")]
@@ -94,13 +95,11 @@ impl<'a> MergeRequestsLister<'a> {
 
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> MergeRequests {
+    pub fn list(&self) -> Result<MergeRequests> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let merge_requests: Result<MergeRequests, serde_json::Error> = self.gl.get(&query);
-
-        merge_requests.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/merge_requests/mod.rs
+++ b/src/merge_requests/mod.rs
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/merge_requests", TEST_PROJECT_ID);
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn build_query_iid() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/merge_requests?iid=456", TEST_PROJECT_ID);
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn build_query_state() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/merge_requests?state=opened", TEST_PROJECT_ID);
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/merge_requests?order_by=created_at",
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/merge_requests?sort=asc", TEST_PROJECT_ID);
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/merge_requests?iid[]=456&iid[]=789&order_by=created_at&sort=asc",

--- a/src/merge_requests/single.rs
+++ b/src/merge_requests/single.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}/merge_requests/{}", TEST_PROJECT_ID, TEST_MR_ID);

--- a/src/merge_requests/single.rs
+++ b/src/merge_requests/single.rs
@@ -18,12 +18,13 @@
 //!
 
 
-use serde_json;
 // use serde_urlencoded;
 
 use BuildQuery;
 
 use merge_requests::MergeRequest;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -45,13 +46,11 @@ impl<'a> MergeRequestLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of merge requests.
-    pub fn list(&self) -> MergeRequest {
+    pub fn list(&self) -> Result<MergeRequest> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let merge_request: Result<MergeRequest, serde_json::Error> = self.gl.get(&query);
-
-        merge_request.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/all.rs
+++ b/src/projects/all.rs
@@ -21,13 +21,13 @@
 //! | `search` | string | no | Return list of authorized projects matching the search criteria |
 
 
-
-use serde_json;
 use serde_urlencoded;
 
 use BuildQuery;
 use Projects;
 use projects::{AllProjectListerInternal, ListingOrderBy};
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -76,14 +76,12 @@ impl<'a> ProjectsLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Projects {
+    pub fn list(&self) -> Result<Projects> {
         // let query = serde_urlencoded::to_string(&self);
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let projects: Result<Projects, serde_json::Error> = self.gl.get(&query);
-
-        projects.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/all.rs
+++ b/src/projects/all.rs
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/all";
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn build_query_archived() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/all?archived=true";
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn build_query_visibility() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/all?visibility=public";
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/all?order_by=id";
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/all?sort=asc";
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn build_query_search() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/all?search=SearchPattern";
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/all?archived=false&sort=asc";

--- a/src/projects/id.rs
+++ b/src/projects/id.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn build_query_id() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/{}", TEST_PROJECT_ID);

--- a/src/projects/id.rs
+++ b/src/projects/id.rs
@@ -20,11 +20,11 @@
 //! | `id` | integer/string | yes | The ID or `NAMESPACE/PROJECT_NAME` of the project |
 
 
-use serde_json;
-
 use BuildQuery;
 use Project;
 use projects::ListingId;
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -40,14 +40,12 @@ impl<'a> ProjectsLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Project {
+    pub fn list(&self) -> Result<Project> {
         // let query = serde_urlencoded::to_string(&self);
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let project: Result<Project, serde_json::Error> = self.gl.get(&query);
-
-        project.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -23,7 +23,6 @@
 //!
 
 
-use serde_json;
 use serde_urlencoded;
 
 use BuildQuery;
@@ -41,6 +40,8 @@ pub mod owned;
 pub mod search;
 pub mod starred;
 pub mod visible;
+
+use ::errors::*;
 
 
 
@@ -126,13 +127,11 @@ impl<'a> ProjectsLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Projects {
+    pub fn list(&self) -> Result<Projects> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let projects: Result<Projects, serde_json::Error> = self.gl.get(&query);
-
-        projects.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -159,7 +159,7 @@ mod tests {
     fn build_query_default() {
         let expected_string = "projects";
 
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let projects_lister = gl.projects();
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn build_query_archived() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects?archived=true";
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn build_query_visibility() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects?visibility=public";
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects?order_by=id";
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects?sort=asc";
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn build_query_search() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects?search=SearchPattern";
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn build_query_simple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects?simple=true";
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects?archived=true&simple=true";

--- a/src/projects/owned.rs
+++ b/src/projects/owned.rs
@@ -21,12 +21,13 @@
 //! | `search` | string | no | Return list of authorized projects matching the search criteria |
 
 
-use serde_json;
 use serde_urlencoded;
 
 use BuildQuery;
 use Projects;
 use projects::{OwnedProjectListerInternal, ListingOrderBy};
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -75,14 +76,12 @@ impl<'a> ProjectsLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Projects {
+    pub fn list(&self) -> Result<Projects> {
         // let query = serde_urlencoded::to_string(&self);
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let projects: Result<Projects, serde_json::Error> = self.gl.get(&query);
-
-        projects.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/owned.rs
+++ b/src/projects/owned.rs
@@ -111,7 +111,7 @@ mod tests {
     fn build_query_default() {
         let expected_string = "projects/owned";
 
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let projects_lister = gl.projects().owned();
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn build_query_archived() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/owned?archived=true";
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn build_query_visibility() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/owned?visibility=public";
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/owned?order_by=id";
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/owned?sort=asc";
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn build_query_search() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/owned?search=SearchPattern";
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "projects/owned?archived=true&sort=desc";

--- a/src/projects/search.rs
+++ b/src/projects/search.rs
@@ -19,12 +19,13 @@
 //! | `sort` | string | no | Return requests sorted in `asc` or `desc` order |
 
 
-use serde_json;
 use serde_urlencoded;
 
 use BuildQuery;
 use Projects;
 use projects::{SearchProjectListerInternal, ListingOrderBy};
+
+use ::errors::*;
 
 
 #[derive(Debug, Clone)]
@@ -58,14 +59,12 @@ impl<'a> ProjectsLister<'a> {
     }
 
     /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Projects {
+    pub fn list(&self) -> Result<Projects> {
         // let query = serde_urlencoded::to_string(&self);
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        let projects: Result<Projects, serde_json::Error> = self.gl.get(&query);
-
-        projects.unwrap()
+        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/search.rs
+++ b/src/projects/search.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn build_query_default() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/search/{}", TEST_SEARCH_QUERY);
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn build_query_order_by() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/search/{}?order_by=id", TEST_SEARCH_QUERY);
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn build_query_sort() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/search/{}?sort=asc", TEST_SEARCH_QUERY);
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn groups_build_query_multiple() {
-        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX");
+        let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
         let expected_string = format!("projects/search/{}?order_by=created_at&sort=desc",


### PR DESCRIPTION
Use error-chain crate for proper error handling.

Since it's an API change, bump version to 0.4.0 (from 0.3.0).