### PR TITLE
Add methods for chaining calls

### DIFF
--- a/examples/list_projects.rs
+++ b/examples/list_projects.rs
@@ -74,5 +74,36 @@ fn run() -> Result<()> {
         .chain_err(|| "cannot get projects")?;
     println!("projects: {:?}", projects);
 
+    let project = gl
+        .projects()
+        .id(gitlab::projects::ListingId::Id(9))
+        .list()
+        .chain_err(|| "failure to find project")?;
+    println!("project: {:?}", project);
+
+    let issues = project
+        .issues(&gl)
+        .list()
+        .chain_err(|| "failure to find project's issues")?;
+    println!("issues: {:?}", issues);
+
+    let issues = gl
+        .projects()
+        .id(gitlab::projects::ListingId::Id(9))
+        .issues()
+        .chain_err(|| "failure to build a gitlab::issues::project::IssuesLister")?
+        .list()
+        .chain_err(|| "failure to find issues")?;
+    println!("issues: {:?}", issues);
+
+    let merge_requests = gl
+        .projects()
+        .id(gitlab::projects::ListingId::Id(9))
+        .merge_requests()
+        .chain_err(|| "failure to build a gitlab::merge_requests::project::IssuesLister")?
+        .list()
+        .chain_err(|| "failure to find merge requests")?;
+    println!("merge_requests: {:?}", merge_requests);
+
     Ok(())
 }

--- a/examples/list_projects.rs
+++ b/examples/list_projects.rs
@@ -87,6 +87,12 @@ fn run() -> Result<()> {
         .chain_err(|| "failure to find project's issues")?;
     println!("issues: {:?}", issues);
 
+    let merge_requests = project
+        .merge_requests(&gl)
+        .list()
+        .chain_err(|| "failure to find project's merge_requests")?;
+    println!("merge_requests: {:?}", merge_requests);
+
     let issues = gl
         .projects()
         .id(gitlab::projects::ListingId::Id(9))

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -290,6 +290,26 @@ mod tests {
         }
     }
 
+    #[test]
+    fn impl_debug_for_gitlab() {
+        let gl = GitLab::new("gitlab.com", "XXXXXXXXXXXXXXXXXXXX").unwrap();
+
+        let debug = format!("{:?}", gl);
+        assert_eq!("GitLab { scheme: https, domain: gitlab.com, port: no port provided, private_token: XXXXXXXXXXXXXXXXXXXX, pagination: None }", debug);
+
+        let gl = gl.scheme("http").port(80);
+        let debug = format!("{:?}", gl);
+        assert_eq!("GitLab { scheme: http, domain: gitlab.com, port: no port provided, private_token: XXXXXXXXXXXXXXXXXXXX, pagination: None }", debug);
+
+        let mut gl = gl.port(81);
+        let debug = format!("{:?}", gl);
+        assert_eq!("GitLab { scheme: http, domain: gitlab.com, port: 81, private_token: XXXXXXXXXXXXXXXXXXXX, pagination: None }", debug);
+
+        gl.set_pagination(Pagination {page: 2, per_page: 5});
+        let debug = format!("{:?}", gl);
+        assert_eq!("GitLab { scheme: http, domain: gitlab.com, port: 81, private_token: XXXXXXXXXXXXXXXXXXXX, pagination: Some(Pagination { page: 2, per_page: 5 }) }", debug);
+    }
+
 
     #[test]
     fn new_valid() {

--- a/src/merge_requests/serde_types.in.rs
+++ b/src/merge_requests/serde_types.in.rs
@@ -70,7 +70,7 @@ pub struct MergeRequest {
     milestone: Option<::Milestone>,
     merge_when_build_succeeds: bool,
     merge_status: Status,
-    sha: String,
+    sha: Option<String>,
     merge_commit_sha: Option<String>,
     subscribed: bool,
     user_notes_count: i64,

--- a/src/projects/id.rs
+++ b/src/projects/id.rs
@@ -39,6 +39,7 @@ impl<'a> ProjectsLister<'a> {
         ProjectsLister { gl: gl, id: id }
     }
 
+
     /// Commit the lister: Query GitLab and return a list of projects.
     pub fn list(&self) -> Result<Project> {
         // let query = serde_urlencoded::to_string(&self);

--- a/src/projects/id.rs
+++ b/src/projects/id.rs
@@ -55,6 +55,13 @@ impl<'a> ProjectsLister<'a> {
 
         Ok(::issues::project::IssuesLister::new(self.gl, project.id))
     }
+
+    /// Return a lister for the project's merge requests
+    pub fn merge_requests(self) -> Result<::merge_requests::MergeRequestsLister<'a>> {
+        let project = self.list().chain_err(|| "failure to find project")?;
+
+        Ok(::merge_requests::MergeRequestsLister::new(self.gl, project.id))
+    }
 }
 
 impl<'a> BuildQuery for ProjectsLister<'a> {

--- a/src/projects/id.rs
+++ b/src/projects/id.rs
@@ -47,6 +47,14 @@ impl<'a> ProjectsLister<'a> {
 
         self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
+
+
+    /// Return a lister for the project's issues
+    pub fn issues(self) -> Result<::issues::project::IssuesLister<'a>> {
+        let project = self.list().chain_err(|| "failure to find project")?;
+
+        Ok(::issues::project::IssuesLister::new(self.gl, project.id))
+    }
 }
 
 impl<'a> BuildQuery for ProjectsLister<'a> {

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -26,6 +26,7 @@
 use serde_urlencoded;
 
 use BuildQuery;
+use Project;
 use Projects;
 
 
@@ -148,6 +149,15 @@ impl<'a> BuildQuery for ProjectsLister<'a> {
         query
     }
 }
+
+
+impl<'a> Project {
+    /// Return a lister for the project's issues
+    pub fn issues(&'a self, gl: &'a ::GitLab) -> ::issues::IssuesLister {
+        ::issues::IssuesLister::new(gl)
+    }
+}
+
 
 
 #[cfg(test)]

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -159,7 +159,7 @@ impl<'a> Project {
 
     /// Return a lister for the project's merge requests
     pub fn merge_requests(&'a self, gl: &'a ::GitLab) -> ::merge_requests::MergeRequestsLister {
-        ::merge_requests::MergeRequestsLister::new(gl)
+        ::merge_requests::MergeRequestsLister::new(gl, self.id)
     }
 }
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -156,6 +156,11 @@ impl<'a> Project {
     pub fn issues(&'a self, gl: &'a ::GitLab) -> ::issues::IssuesLister {
         ::issues::IssuesLister::new(gl)
     }
+
+    /// Return a lister for the project's merge requests
+    pub fn merge_requests(&'a self, gl: &'a ::GitLab) -> ::merge_requests::MergeRequestsLister {
+        ::merge_requests::MergeRequestsLister::new(gl)
+    }
 }
 
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -153,8 +153,8 @@ impl<'a> BuildQuery for ProjectsLister<'a> {
 
 impl<'a> Project {
     /// Return a lister for the project's issues
-    pub fn issues(&'a self, gl: &'a ::GitLab) -> ::issues::IssuesLister {
-        ::issues::IssuesLister::new(gl)
+    pub fn issues(&'a self, gl: &'a ::GitLab) -> ::issues::project::IssuesLister {
+        ::issues::project::IssuesLister::new(gl, self.id)
     }
 
     /// Return a lister for the project's merge requests


### PR DESCRIPTION
Add methods (e.g. `issues()` and `merge_requests()`) to the `Project` struct so that once we have a specific project we can list its issues and merge requests.
