### PR TITLE
Add higher level methods to `GitLab`

### DIFF
--- a/examples/list_groups.rs
+++ b/examples/list_groups.rs
@@ -5,7 +5,6 @@ use std::env;
 extern crate log;
 extern crate env_logger;
 
-use gitlab::Lister;
 use gitlab::errors::*;
 
 

--- a/examples/list_groups.rs
+++ b/examples/list_groups.rs
@@ -54,10 +54,6 @@ fn run() -> Result<()> {
     // let mut gl = gitlab::GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?.scheme("http").port(80);
     // gl = gl.scheme("http").port(80);
 
-    gl.set_pagination(gitlab::Pagination {
-        page: 1,
-        per_page: 100,
-    });
     println!("gl: {:?}", gl);
 
     let groups = gl.groups().list().chain_err(|| "cannot get groups")?;

--- a/examples/list_groups.rs
+++ b/examples/list_groups.rs
@@ -5,6 +5,7 @@ use std::env;
 extern crate log;
 extern crate env_logger;
 
+use gitlab::Lister;
 use gitlab::errors::*;
 
 

--- a/examples/list_issues.rs
+++ b/examples/list_issues.rs
@@ -8,6 +8,7 @@ extern crate env_logger;
 use gitlab::GitLab;
 // use gitlab::Pagination;
 use gitlab::issues;
+use gitlab::Lister;
 
 use gitlab::errors::*;
 

--- a/examples/list_merge_requests.rs
+++ b/examples/list_merge_requests.rs
@@ -6,6 +6,7 @@ extern crate log;
 extern crate env_logger;
 
 use gitlab::GitLab;
+use gitlab::Lister;
 
 use gitlab::errors::*;
 

--- a/examples/list_projects.rs
+++ b/examples/list_projects.rs
@@ -55,7 +55,10 @@ fn run() -> Result<()> {
     };
 
     let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?;
-    // let gl = GitLab::new(&hostname, &token).chain_err(|| "failure to create GitLab instance")?.scheme("http").port(80);
+    // let gl = GitLab::new(&hostname, &token)
+    //     .chain_err(|| "failure to create GitLab instance")?
+    //     .scheme("http")
+    //     .port(80);
     // let gl = gl.scheme("http").port(80);
 
     let projects = gl.projects().list().chain_err(|| "cannot get projects")?;

--- a/examples/list_projects.rs
+++ b/examples/list_projects.rs
@@ -8,6 +8,7 @@ extern crate env_logger;
 
 use gitlab::GitLab;
 // use gitlab::Pagination;
+use gitlab::Lister;
 
 use gitlab::errors::*;
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -271,15 +271,8 @@ impl GitLab {
         loop {
             let projects = self.projects().search(name.to_string()).list().chain_err(|| "cannot get projects")?;
 
-            // Loop over the found projects
-            for project in projects {
-                println!("############# project: {:?}", project);
-
-                if project.namespace.name == namespace && project.name == name {
-                    found_project = Some(project);
-                    break;
-                }
-            }
+            // Find the right project in the vector
+            found_project = projects.into_iter().find(|ref project| project.namespace.name == namespace && project.name == name);
 
             if found_project.is_some() {
                 break;

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -271,10 +271,12 @@ impl GitLab {
         loop {
             let projects = self.projects().search(name.to_string()).list().chain_err(|| "cannot get projects")?;
 
+            let nb_projects_found = projects.len();
+
             // Find the right project in the vector
             found_project = projects.into_iter().find(|ref project| project.namespace.name == namespace && project.name == name);
 
-            if found_project.is_some() {
+            if found_project.is_some() || nb_projects_found < self.pagination.unwrap().per_page as usize {
                 break;
             }
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -250,6 +250,42 @@ impl GitLab {
     //     info!("query: {:?}", query);
     //     self.get(&query)
     // }
+
+    // Higher level methods
+
+    pub fn get_project(&mut self, namespace: &str, name: &str) -> Result<::Project> {
+        // We can't search for "namespace/name", so we search for "name", and loop on the result
+        // until we find the proper "namespace/name".
+        // NOTE: Since our search match could contain many results and they will be paginated,
+        //       we need two loops: one on content of a page, one for the pages.
+
+        let projects_lister = self.projects().search(name.to_string());
+        println!("projects_lister: {:?}", projects_lister);
+
+        let initial_pagination = self.pagination;
+        let mut pagination = Pagination {page: 1, per_page: 20};
+
+        // Query GitLab inside the page loop
+        loop {
+            // Bump for the next page
+            self.pagination = Some(pagination);
+
+            let projects = projects_lister.list().chain_err(|| "cannot get projects")?;
+
+            // Loop over the found projects
+            for project in projects {
+                println!("############# project: {:?}", project);
+            }
+
+            // pagination.page = pagination.page + 1;
+            pagination.page += 1;
+        }
+
+        // Restore the initial pagination
+        self.pagination = initial_pagination;
+
+        unimplemented!();
+    }
 }
 
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -165,7 +165,8 @@ impl GitLab {
     ///
     /// The method _can_ be paginated if `page` and `per_page` is provided.
     ///
-    /// NOTE:
+    /// Notes:
+    ///
     /// * This method is meant to be used internally;
     /// * Until all `BuildQuery::build_query()`s use `serde_urlencoded`, the `query` paramter will
     ///   have to remain a string.

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -282,9 +282,7 @@ impl GitLab {
     ///
     /// Because we need to search (and thus query the GitLab server possibly multiple times), this
     /// _can_ be a slow operation if there is many issues in the project.
-    pub fn get_issue<'a>(&'a mut self, namespace: &str, name: &str, iid: i64) -> Result<::Issue> {
-        // let issues = self.issues().project(project.id).list().chain_err(...)?;
-        // let mrs    = self.merge_requests(project.id).list().chain_err(...)?;
+    pub fn get_issue(&self, namespace: &str, name: &str, iid: i64) -> Result<::Issue> {
         self.high_level_get(namespace, name, iid, |project_id| self.issues().project(project_id))
     }
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -157,6 +157,20 @@ impl GitLab {
     // }
 
 
+    /// Perform an HTTP GET to the GitLab server from a specific query.
+    ///
+    /// The `query` is simply the string part appearing in the GET URL.
+    /// For example, for a `GET https://www.example.com/projects/:id/merge_requests?iid=42`, the
+    /// `query` is `projects/:id/merge_requests?iid=42`.
+    ///
+    /// The method _can_ be paginated if `page` and `per_page` is provided.
+    ///
+    /// NOTE:
+    /// * This method is meant to be used internally;
+    /// * Until all `BuildQuery::build_query()`s use `serde_urlencoded`, the `query` paramter will
+    ///   have to remain a string.
+    ///
+    /// Returns a specific GitLab type, wrapped in a `Result`.
     pub fn get<T, U>(&self, query: &str, page: U, per_page: U) -> Result<T>
         where T: serde::Deserialize,
               U: Into<Option<u16>>

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -292,6 +292,59 @@ impl GitLab {
             Some(project) => Ok(project)
         }
     }
+
+    /// Get a project issue from a its `iid`.
+    ///
+    /// Since GitLab uses unique `id`s in its API and _not_ `iid`s, we will need to list issues
+    /// (grouped by pages of 20) until we find the proper issue matching the `id` requested.
+    ///
+    /// **Note**: A `iid` is the issue number as seen by normal user, for example appearing on
+    /// a GitLab URL. This `iid` can be used to reference an issue (in other issues, in commit
+    /// messages, etc.) by prepending a pound sign to it, for example `#3`. An `id`, instead, is
+    /// GitLab's internal and unique id associated with the issue.
+    ///
+    /// Because we need to search (and thus query the GitLab server possibly multiple times), this
+    /// _can_ be a slow operation if there is many issues in the project.
+    pub fn get_issue(&mut self, namespace: &str, name: &str, iid: i64) -> Result<::Issue> {
+        let project = self.get_project(namespace, name).chain_err(|| format!("cannot get project '{}/{}'", namespace, name))?;
+
+        // NOTE: We can't use `self.issues().single(project.id, id).list()` since
+        //       the `id` is the _gitlab internal_ id, not the `iid`. We'll unfortunately have to
+        //       search for the issue instead.
+
+        // Store the initial pagination so we can restore it later
+        let initial_pagination = self.pagination.clone();
+
+        // Set a default value for the pagination if it's None
+        self.pagination = self.pagination.or(Some(Pagination {page: 1, per_page: 20}));
+
+        let mut found_issue: Option<::Issue>;
+
+        // Query GitLab inside the page loop
+        loop {
+            let issues = self.issues().project(project.id).list().chain_err(|| format!("cannot get issues for project '{}/{}'", project.namespace.name, project.name))?;
+
+            let issues_found = issues.len();
+
+            // Find the right issue in the vector
+            found_issue = issues.into_iter().find(|ref issue| issue.iid == iid);
+
+            if found_issue.is_some() || issues_found < self.pagination.unwrap().per_page as usize {
+                break;
+            }
+
+            // Bump to the next page
+            self.pagination.as_mut().map(|pagination| pagination.page += 1);
+        }
+
+        // Restore the initial pagination
+        self.pagination = initial_pagination;
+
+        match found_issue {
+            None => bail!(format!("Issue iid={} for project '{}/{}' not found!", iid, project.namespace.name, project.name)),
+            Some(issue) => Ok(issue)
+        }
+    }
 }
 
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -10,7 +10,6 @@ use serde_json;
 
 // use Groups;
 use Lister;
-use GitLabItem;
 
 use ::errors::*;
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -311,7 +311,7 @@ impl GitLab {
         self.get_paginated_from_project(query_gitlab_closure, iter_find_closure)
     }
 
-    /// Get a project issue from a its `iid`.
+    /// Get a project issue from a its project's `namespace` and `name` and the issue's `iid`.
     ///
     /// Since GitLab uses unique `id`s in its API and _not_ `iid`s, we will need to list issues
     /// (grouped by pages of 20) until we find the proper issue matching the `id` requested.
@@ -336,7 +336,7 @@ impl GitLab {
         self.get_paginated_from_project(query_gitlab_closure, iter_find_closure)
     }
 
-    /// Get a project merge request from a its `iid`.
+    /// Get a project merge request from a its project's `namespace` and `name` and the issue's `iid`.
     ///
     /// Since GitLab uses unique `id`s in its API and _not_ `iid`s, we will need to list issues
     /// (grouped by pages of 20) until we find the proper issue matching the `id` requested.

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -314,10 +314,9 @@ impl GitLab {
 
         // Query GitLab inside the page loop
         loop {
-            // FIXME: Use list_paginated()
             let projects = self.projects()
                 .search(name.to_string())
-                .list()
+                .list_paginated(pagination_page, pagination_per_page)
                 .chain_err(|| "cannot get projects")?;
 
             let nb_projects_found = projects.len();

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -1,7 +1,6 @@
 
-use std::fmt;
 use std::io::Read;  // Trait providing read_to_string()
-use std::env;
+use std;
 
 use url;
 use hyper;
@@ -29,8 +28,8 @@ pub struct GitLab {
 
 
 // Explicitly implement Debug trait for GitLab so we can hide the token.
-impl fmt::Debug for GitLab {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl std::fmt::Debug for GitLab {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f,
                "GitLab {{ scheme: {}, domain: {}, port: {}, private_token: XXXXXXXXXXXXXXXXXXXX }}",
                self.url.scheme(),
@@ -89,7 +88,7 @@ impl GitLab {
         Ok(GitLab {
             url: url,
             private_token: private_token.to_string(),
-            client: match env::var("HTTP_PROXY") {
+            client: match std::env::var("HTTP_PROXY") {
                 Ok(proxy) => {
                     let proxy: Vec<&str> = proxy.trim_left_matches("http://").split(':').collect();
                     let hostname = proxy[0].to_string();

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -310,22 +310,22 @@ impl GitLab {
         let mut pagination_page = 1;
         let pagination_per_page = 20;
 
-        let mut found_project: Option<::Project>;
+        let mut found: Option<::Project>;
 
         // Query GitLab inside the page loop
         loop {
-            let projects = self.projects()
+            let found_items = self.projects()
                 .search(name.to_string())
                 .list_paginated(pagination_page, pagination_per_page)
                 .chain_err(|| "cannot get projects")?;
 
-            let nb_projects_found = projects.len();
+            let nb_found = found_items.len();
 
             // Find the right project in the vector
-            found_project = projects.into_iter()
+            found = found_items.into_iter()
                 .find(|ref project| project.namespace.name == namespace && project.name == name);
 
-            if found_project.is_some() || nb_projects_found < pagination_per_page as usize {
+            if found.is_some() || nb_found < pagination_per_page as usize {
                 break;
             }
 
@@ -333,9 +333,9 @@ impl GitLab {
             pagination_page += 1;
         }
 
-        match found_project {
+        match found {
             None => bail!(format!("Project '{}/{}' not found!", namespace, name)),
-            Some(project) => Ok(project),
+            Some(item) => Ok(item),
         }
     }
 

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -265,7 +265,7 @@ impl GitLab {
         // Set a default value for the pagination if it's None
         self.pagination = self.pagination.or(Some(Pagination {page: 1, per_page: 20}));
 
-        let mut found_project: Option<::Project> = None;
+        let mut found_project: Option<::Project>;
 
         // Query GitLab inside the page loop
         loop {

--- a/src/groups/details.rs
+++ b/src/groups/details.rs
@@ -42,7 +42,7 @@ impl<'a> GroupLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -116,7 +116,7 @@ impl<'a> GroupsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/groups/owned.rs
+++ b/src/groups/owned.rs
@@ -33,7 +33,7 @@ impl<'a> GroupsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/groups/projects.rs
+++ b/src/groups/projects.rs
@@ -95,7 +95,7 @@ impl<'a> ProjectsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/issues/group.rs
+++ b/src/issues/group.rs
@@ -231,7 +231,10 @@ mod tests {
         // let gl: ::GitLab = Default::default();
 
         let expected_string = "groups/123/issues?milestone=Test+Milestone";
-        let query = gl.issues().group(TEST_PROJECT_ID).milestone("Test Milestone".to_string()).build_query();
+        let query = gl.issues()
+            .group(TEST_PROJECT_ID)
+            .milestone("Test Milestone".to_string())
+            .build_query();
         assert_eq!(query, expected_string);
     }
 

--- a/src/issues/group.rs
+++ b/src/issues/group.rs
@@ -93,7 +93,7 @@ impl<'a> IssuesLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/issues/mod.rs
+++ b/src/issues/mod.rs
@@ -23,7 +23,6 @@
 
 use BuildQuery;
 use Lister;
-use GitLabItem;
 use Issues;
 use Issue;
 
@@ -45,13 +44,6 @@ include!(concat!(env!("OUT_DIR"), "/issues/serde_types.rs"));
 pub struct IssuesLister<'a> {
     gl: &'a ::GitLab,
     internal: IssuesListerInternal,
-}
-
-
-impl GitLabItem for Issue {
-    fn iid(&self) -> i64 {
-        self.iid
-    }
 }
 
 

--- a/src/issues/mod.rs
+++ b/src/issues/mod.rs
@@ -22,7 +22,10 @@
 // use serde_urlencoded;
 
 use BuildQuery;
+use Lister;
+use GitLabItem;
 use Issues;
+use Issue;
 
 pub mod group;
 pub mod project;
@@ -42,6 +45,32 @@ include!(concat!(env!("OUT_DIR"), "/issues/serde_types.rs"));
 pub struct IssuesLister<'a> {
     gl: &'a ::GitLab,
     internal: IssuesListerInternal,
+}
+
+
+impl GitLabItem for Issue {
+    fn iid(&self) -> i64 {
+        self.iid
+    }
+}
+
+
+impl<'a> Lister<Issues> for IssuesLister<'a> {
+    /// Commit the lister: Query GitLab and return a list of issues.
+    fn list(&self) -> Result<Issues> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
+    }
+
+    /// Commit the lister: Query GitLab and return a list of issues.
+    fn list_paginated(&self, page: u16, per_page: u16) -> Result<Issues> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, page, per_page).chain_err(|| format!("cannot get query {}", query))
+    }
 }
 
 
@@ -96,13 +125,13 @@ impl<'a> IssuesLister<'a> {
     }
 
 
-    /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Result<Issues> {
-        let query = self.build_query();
-        debug!("query: {:?}", query);
-
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
-    }
+    // /// Commit the lister: Query GitLab and return a list of issues.
+    // pub fn list(&self) -> Result<Issues> {
+    //     let query = self.build_query();
+    //     debug!("query: {:?}", query);
+    //
+    //     self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
+    // }
 }
 
 

--- a/src/issues/mod.rs
+++ b/src/issues/mod.rs
@@ -24,7 +24,6 @@
 use BuildQuery;
 use Lister;
 use Issues;
-use Issue;
 
 pub mod group;
 pub mod project;

--- a/src/issues/project.rs
+++ b/src/issues/project.rs
@@ -33,6 +33,7 @@
 use serde_urlencoded;
 
 use BuildQuery;
+use Lister;
 use Issues;
 use issues::ProjectsIssuesListerInternal;
 
@@ -45,6 +46,17 @@ pub struct IssuesLister<'a> {
     /// The ID of a group
     id: i64,
     internal: ProjectsIssuesListerInternal,
+}
+
+
+impl<'a> Lister<Issues> for IssuesLister<'a> {
+    /// Commit the lister: Query GitLab and return a list of issues.
+    fn list(&self) -> Result<Issues> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
+    }
 }
 
 
@@ -93,15 +105,6 @@ impl<'a> IssuesLister<'a> {
     pub fn sort(&'a mut self, sort: ::ListingSort) -> &'a mut IssuesLister {
         self.internal.sort = Some(sort);
         self
-    }
-
-
-    /// Commit the lister: Query GitLab and return a list of issues.
-    pub fn list(&self) -> Result<Issues> {
-        let query = self.build_query();
-        debug!("query: {:?}", query);
-
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
     }
 }
 
@@ -197,6 +200,8 @@ impl<'a> BuildQuery for IssuesLister<'a> {
         query
     }
 }
+
+
 
 #[cfg(test)]
 mod tests {

--- a/src/issues/project.rs
+++ b/src/issues/project.rs
@@ -254,8 +254,12 @@ mod tests {
         let gl = ::GitLab::new(&"localhost", "XXXXXXXXXXXXXXXXXXXX").unwrap();
         // let gl: ::GitLab = Default::default();
 
-        let expected_string = format!("projects/{}/issues?milestone=Test+Milestone", TEST_PROJECT_ID);
-        let query = gl.issues().project(TEST_PROJECT_ID).milestone("Test Milestone".to_string()).build_query();
+        let expected_string = format!("projects/{}/issues?milestone=Test+Milestone",
+                                      TEST_PROJECT_ID);
+        let query = gl.issues()
+            .project(TEST_PROJECT_ID)
+            .milestone("Test Milestone".to_string())
+            .build_query();
         assert_eq!(query, expected_string);
     }
 

--- a/src/issues/project.rs
+++ b/src/issues/project.rs
@@ -57,6 +57,13 @@ impl<'a> Lister<Issues> for IssuesLister<'a> {
 
         self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
+
+    fn list_paginated(&self, page: u16, per_page: u16) -> Result<Issues> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, page, per_page).chain_err(|| format!("cannot get query {}", query))
+    }
 }
 
 

--- a/src/issues/single.rs
+++ b/src/issues/single.rs
@@ -48,7 +48,7 @@ impl<'a> IssueLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod errors {
     error_chain!{}
 }
 
+use ::errors::*;
+
 
 #[cfg(feature = "serde_derive")]
 include!("serde_types.in.rs");
@@ -44,15 +46,28 @@ pub mod issues;
 pub mod merge_requests;
 
 // Re-export those structs
-pub use gitlab::Pagination;
 pub use gitlab::GitLab;
 // pub use projects::Project;
+// Re-export those traits
 
 
 trait BuildQuery {
     fn build_query(&self) -> String;
 }
 
+pub trait Lister<T> {
+    fn list(&self) -> Result<T>;
+    // fn list_paginated(&self, page: u16, per_page: u16) -> Result<T>;
+    // FIXME: Remove default implementation, will have to implement this for other structs.
+    //        See src/issues/mod.rs
+    fn list_paginated(&self, _page: u16, _per_page: u16) -> Result<T> {
+        self.list()
+    }
+}
+
+pub trait GitLabItem {
+    fn iid(&self) -> i64;
+}
 
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,12 +57,7 @@ trait BuildQuery {
 
 pub trait Lister<T> {
     fn list(&self) -> Result<T>;
-    // fn list_paginated(&self, page: u16, per_page: u16) -> Result<T>;
-    // FIXME: Remove default implementation, will have to implement this for other structs.
-    //        See src/issues/mod.rs
-    fn list_paginated(&self, _page: u16, _per_page: u16) -> Result<T> {
-        self.list()
-    }
+    fn list_paginated(&self, page: u16, per_page: u16) -> Result<T>;
 }
 
 pub trait GitLabItem {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,6 @@ pub trait Lister<T> {
     fn list_paginated(&self, page: u16, per_page: u16) -> Result<T>;
 }
 
-pub trait GitLabItem {
-    fn iid(&self) -> i64;
-}
-
 
 #[cfg(test)]
 mod tests {

--- a/src/merge_requests/mod.rs
+++ b/src/merge_requests/mod.rs
@@ -30,6 +30,8 @@
 // use serde_urlencoded;
 
 use BuildQuery;
+use Lister;
+use GitLabItem;
 
 pub mod single;
 
@@ -47,6 +49,32 @@ pub struct MergeRequestsLister<'a> {
     gl: &'a ::GitLab,
     id: i64,
     internal: MergeRequestsListerInternal,
+}
+
+
+impl GitLabItem for MergeRequest {
+    fn iid(&self) -> i64 {
+        self.iid
+    }
+}
+
+
+impl<'a> Lister<MergeRequests> for MergeRequestsLister<'a> {
+    /// Commit the lister: Query GitLab and return a list of projects.
+    fn list(&self) -> Result<MergeRequests> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
+    }
+
+    /// Commit the lister: Query GitLab and return a list of issues.
+    fn list_paginated(&self, page: u16, per_page: u16) -> Result<MergeRequests> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, page, per_page).chain_err(|| format!("cannot get query {}", query))
+    }
 }
 
 
@@ -91,15 +119,6 @@ impl<'a> MergeRequestsLister<'a> {
     fn sort(&'a mut self, sort: ::ListingSort) -> &'a mut MergeRequestsLister {
         self.internal.sort = Some(sort);
         self
-    }
-
-
-    /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Result<MergeRequests> {
-        let query = self.build_query();
-        debug!("query: {:?}", query);
-
-        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/merge_requests/mod.rs
+++ b/src/merge_requests/mod.rs
@@ -99,7 +99,7 @@ impl<'a> MergeRequestsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/merge_requests/mod.rs
+++ b/src/merge_requests/mod.rs
@@ -31,7 +31,6 @@
 
 use BuildQuery;
 use Lister;
-use GitLabItem;
 
 pub mod single;
 
@@ -49,13 +48,6 @@ pub struct MergeRequestsLister<'a> {
     gl: &'a ::GitLab,
     id: i64,
     internal: MergeRequestsListerInternal,
-}
-
-
-impl GitLabItem for MergeRequest {
-    fn iid(&self) -> i64 {
-        self.iid
-    }
 }
 
 

--- a/src/merge_requests/serde_types.in.rs
+++ b/src/merge_requests/serde_types.in.rs
@@ -12,7 +12,7 @@ pub enum State {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-enum Status {
+pub enum Status {
     #[serde(rename = "can_be_merged")]
     CanBeMerged,
     #[serde(rename = "cannot_be_merged")]
@@ -34,7 +34,7 @@ pub enum ListingOrderBy {
 
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct MergeRequestsListerInternal {
+struct MergeRequestsListerInternal {
     /// Merge request's IID
     iid: Option<Vec<i64>>,
     /// State of the requests
@@ -49,34 +49,34 @@ pub struct MergeRequestsListerInternal {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MergeRequest {
-    id: i64,
-    iid: i64,
-    project_id: i64,
-    title: String,
-    description: String,
-    state: State,
-    created_at: String,  // FIXME: Use chrono crate
-    updated_at: String,  // FIXME: Use chrono crate
-    target_branch: String,
-    source_branch: String,
-    upvotes: i64,
-    downvotes: i64,
-    author: ::User,
-    assignee: Option<::User>,
-    source_project_id: i64,
-    target_project_id: i64,
-    labels: Vec<String>,
-    work_in_progress: bool,
-    milestone: Option<::Milestone>,
-    merge_when_build_succeeds: bool,
-    merge_status: Status,
-    sha: Option<String>,
-    merge_commit_sha: Option<String>,
-    subscribed: bool,
-    user_notes_count: i64,
-    should_remove_source_branch: Option<bool>,
-    force_remove_source_branch: Option<bool>,
-    web_url: String
+    pub id: i64,
+    pub iid: i64,
+    pub project_id: i64,
+    pub title: String,
+    pub description: String,
+    pub state: State,
+    pub created_at: String,  // FIXME: Use chrono crate
+    pub updated_at: String,  // FIXME: Use chrono crate
+    pub target_branch: String,
+    pub source_branch: String,
+    pub upvotes: i64,
+    pub downvotes: i64,
+    pub author: ::User,
+    pub assignee: Option<::User>,
+    pub source_project_id: i64,
+    pub target_project_id: i64,
+    pub labels: Vec<String>,
+    pub work_in_progress: bool,
+    pub milestone: Option<::Milestone>,
+    pub merge_when_build_succeeds: bool,
+    pub merge_status: Status,
+    pub sha: Option<String>,
+    pub merge_commit_sha: Option<String>,
+    pub subscribed: bool,
+    pub user_notes_count: i64,
+    pub should_remove_source_branch: Option<bool>,
+    pub force_remove_source_branch: Option<bool>,
+    pub web_url: String
 }
 
 pub type MergeRequests = Vec<MergeRequest>;

--- a/src/merge_requests/single.rs
+++ b/src/merge_requests/single.rs
@@ -50,7 +50,7 @@ impl<'a> MergeRequestLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/all.rs
+++ b/src/projects/all.rs
@@ -81,7 +81,7 @@ impl<'a> ProjectsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/id.rs
+++ b/src/projects/id.rs
@@ -46,7 +46,7 @@ impl<'a> ProjectsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -26,6 +26,7 @@
 use serde_urlencoded;
 
 use BuildQuery;
+use Lister;
 use Project;
 use Projects;
 
@@ -57,6 +58,25 @@ include!(concat!(env!("OUT_DIR"), "/projects/serde_types.rs"));
 pub struct ProjectsLister<'a> {
     gl: &'a ::GitLab,
     internal: ProjectListerInternal,
+}
+
+
+impl<'a> Lister<Projects> for ProjectsLister<'a> {
+    /// Commit the lister: Query GitLab and return a list of projects.
+    fn list(&self) -> Result<Projects> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
+    }
+
+    /// Commit the lister: Query GitLab and return a list of issues.
+    fn list_paginated(&self, page: u16, per_page: u16) -> Result<Projects> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, page, per_page).chain_err(|| format!("cannot get query {}", query))
+    }
 }
 
 
@@ -125,14 +145,6 @@ impl<'a> ProjectsLister<'a> {
     pub fn simple(&'a mut self, simple: bool) -> &'a mut ProjectsLister {
         self.internal.simple = Some(simple);
         self
-    }
-
-    /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Result<Projects> {
-        let query = self.build_query();
-        debug!("query: {:?}", query);
-
-        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -132,7 +132,7 @@ impl<'a> ProjectsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -376,7 +376,8 @@ mod tests {
         let project_id = 123;
         let project = ::Project { id: project_id, ..Default::default() };
         let issues_lister = format!("{:?}", project.issues(&gl));
-        let default_issues_lister = format!("{:?}", ::issues::project::IssuesLister::new(&gl, project_id));
+        let default_issues_lister = format!("{:?}",
+                                            ::issues::project::IssuesLister::new(&gl, project_id));
         assert_eq!(issues_lister, default_issues_lister);
     }
 
@@ -387,7 +388,9 @@ mod tests {
         let project_id = 123;
         let project = ::Project { id: project_id, ..Default::default() };
         let merge_requests_lister = format!("{:?}", project.merge_requests(&gl));
-        let default_merge_requests_lister = format!("{:?}", ::merge_requests::MergeRequestsLister::new(&gl, project_id));
+        let default_merge_requests_lister =
+            format!("{:?}",
+                    ::merge_requests::MergeRequestsLister::new(&gl, project_id));
         assert_eq!(merge_requests_lister, default_merge_requests_lister);
     }
 }

--- a/src/projects/owned.rs
+++ b/src/projects/owned.rs
@@ -81,7 +81,7 @@ impl<'a> ProjectsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/search.rs
+++ b/src/projects/search.rs
@@ -64,7 +64,7 @@ impl<'a> ProjectsLister<'a> {
         let query = self.build_query();
         debug!("query: {:?}", query);
 
-        self.gl.get(&query).chain_err(|| format!("cannot get query {}", query))
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/projects/search.rs
+++ b/src/projects/search.rs
@@ -22,6 +22,7 @@
 use serde_urlencoded;
 
 use BuildQuery;
+use Lister;
 use Projects;
 use projects::{SearchProjectListerInternal, ListingOrderBy};
 
@@ -35,6 +36,26 @@ pub struct ProjectsLister<'a> {
     query: String,
     internal: SearchProjectListerInternal,
 }
+
+
+impl<'a> Lister<Projects> for ProjectsLister<'a> {
+    /// Commit the lister: Query GitLab and return a list of projects.
+    fn list(&self) -> Result<Projects> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
+    }
+
+    /// Commit the lister: Query GitLab and return a list of issues.
+    fn list_paginated(&self, page: u16, per_page: u16) -> Result<Projects> {
+        let query = self.build_query();
+        debug!("query: {:?}", query);
+
+        self.gl.get(&query, page, per_page).chain_err(|| format!("cannot get query {}", query))
+    }
+}
+
 
 impl<'a> ProjectsLister<'a> {
     pub fn new(gl: &'a ::GitLab, query: String) -> ProjectsLister {
@@ -56,15 +77,6 @@ impl<'a> ProjectsLister<'a> {
     pub fn sort(&'a mut self, sort: ::ListingSort) -> &'a mut ProjectsLister {
         self.internal.sort = Some(sort);
         self
-    }
-
-    /// Commit the lister: Query GitLab and return a list of projects.
-    pub fn list(&self) -> Result<Projects> {
-        // let query = serde_urlencoded::to_string(&self);
-        let query = self.build_query();
-        debug!("query: {:?}", query);
-
-        self.gl.get(&query, None, None).chain_err(|| format!("cannot get query {}", query))
     }
 }
 

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -205,7 +205,7 @@ pub struct Project {
     avatar_url: Option<String>,
     star_count: i64,
     forks_count: i64,
-    open_issues_count: i64,
+    open_issues_count: Option<i64>,
     runners_token: Option<String>,
     public_builds: bool,
     shared_with_groups: Vec<ProjectSharedWithGroup>,

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -190,11 +190,11 @@ pub struct Project {
     path: String,
     path_with_namespace: String,
     container_registry_enabled: Option<bool>,
-    issues_enabled: bool,
-    merge_requests_enabled: bool,
-    wiki_enabled: bool,
-    builds_enabled: bool,
-    snippets_enabled: bool,
+    issues_enabled: Option<bool>,
+    merge_requests_enabled: Option<bool>,
+    wiki_enabled: Option<bool>,
+    builds_enabled: Option<bool>,
+    snippets_enabled: Option<bool>,
     created_at: String,  // FIXME: Date instead?
     last_activity_at: String,  // FIXME: Date instead?
     shared_runners_enabled: bool,

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -38,7 +38,7 @@ pub enum ListingVisibility {
 
 
 #[derive(Debug, Serialize, Deserialize)]
-enum IssueState {
+pub enum IssueState {
     #[serde(rename = "opened")]
     Opened,
 
@@ -48,7 +48,7 @@ enum IssueState {
 
 
 #[derive(Debug, Serialize, Deserialize)]
-enum UserState {
+pub enum UserState {
     #[serde(rename = "active")]
     Active,
 
@@ -58,7 +58,7 @@ enum UserState {
 
 
 #[derive(Debug, Serialize, Deserialize)]
-enum MilestoneState {
+pub enum MilestoneState {
     #[serde(rename = "active")]
     Active,
 
@@ -108,65 +108,65 @@ pub struct ProjectOwner {
 
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ProjectNamespaceAvatar {
-    url: Option<String>,
+pub struct ProjectNamespaceAvatar {
+    pub url: Option<String>,
 }
 
 
 #[derive(Default, Debug, Serialize, Deserialize)]
-struct ProjectNamespace {
-    id: i64,
-    name: String,
-    path: String,
-    owner_id: Option<i64>,  // FIXME: Why would a project not have this?
-    created_at: String,  // FIXME: Date instead?
-    updated_at: String,  // FIXME: Date instead?
-    description: String,
-    avatar: Option<ProjectNamespaceAvatar>,
-    membership_lock: Option<bool>,
-    share_with_group_lock: bool,
-    visibility_level: i64,
-    request_access_enabled: bool,
-    ldap_sync_status: Option<String>,
-    ldap_sync_error: Option<String>,  // FIXME: Is String the proper type?
-    ldap_sync_last_update_at: Option<String>,  // FIXME: Is String the proper type?
-    ldap_sync_last_successful_update_at: Option<String>,  // FIXME: Is String the proper type?
-    ldap_sync_last_sync_at: Option<String>,  // FIXME: Is String the proper type?
-    deleted_at: Option<String>,  // FIXME: Is String the proper type?
-    lfs_enabled: Option<String>,  // FIXME: Is String the proper type?
-    repository_size_limit: Option<String>  // FIXME: Is String the proper type?
+pub struct ProjectNamespace {
+    pub id: i64,
+    pub name: String,
+    pub path: String,
+    pub owner_id: Option<i64>,  // FIXME: Why would a project not have this?
+    pub created_at: String,  // FIXME: Date instead?
+    pub updated_at: String,  // FIXME: Date instead?
+    pub description: String,
+    pub avatar: Option<ProjectNamespaceAvatar>,
+    pub membership_lock: Option<bool>,
+    pub share_with_group_lock: bool,
+    pub visibility_level: i64,
+    pub request_access_enabled: bool,
+    pub ldap_sync_status: Option<String>,
+    pub ldap_sync_error: Option<String>,  // FIXME: Is String the proper type?
+    pub ldap_sync_last_update_at: Option<String>,  // FIXME: Is String the proper type?
+    pub ldap_sync_last_successful_update_at: Option<String>,  // FIXME: Is String the proper type?
+    pub ldap_sync_last_sync_at: Option<String>,  // FIXME: Is String the proper type?
+    pub deleted_at: Option<String>,  // FIXME: Is String the proper type?
+    pub lfs_enabled: Option<String>,  // FIXME: Is String the proper type?
+    pub repository_size_limit: Option<String>  // FIXME: Is String the proper type?
 }
 
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ProjectForkedFrom {
-    id: i64,
-    http_url_to_repo: String,
-    web_url: String,
-    name: String,
-    name_with_namespace: String,
-    path: String,
-    path_with_namespace: String,
+pub struct ProjectForkedFrom {
+    pub id: i64,
+    pub http_url_to_repo: String,
+    pub web_url: String,
+    pub name: String,
+    pub name_with_namespace: String,
+    pub path: String,
+    pub path_with_namespace: String,
 }
 
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ProjectAccess {
-    access_level: i64,
-    notification_level: i64,
+pub struct ProjectAccess {
+    pub access_level: i64,
+    pub notification_level: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ProjectPermissions {
-    project_access: Option<ProjectAccess>,
-    group_access: Option<ProjectAccess>,
+pub struct ProjectPermissions {
+    pub project_access: Option<ProjectAccess>,
+    pub group_access: Option<ProjectAccess>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ProjectSharedWithGroup {
-    group_id: i64,
-    group_name: String,
-    group_access_level: i64,
+pub struct ProjectSharedWithGroup {
+    pub group_id: i64,
+    pub group_name: String,
+    pub group_access_level: i64,
 }
 
 
@@ -174,46 +174,46 @@ struct ProjectSharedWithGroup {
 // https://doc.rust-lang.org/rustc-serialize/rustc_serialize/json/index.html
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Project {
-    id: i64,
-    description: String,
-    default_branch: Option<String>,
-    tag_list: Vec<String>,
-    public: bool,
-    archived: bool,
-    visibility_level: i64,
-    ssh_url_to_repo: String,
-    http_url_to_repo: String,
-    web_url: String,
+    pub id: i64,
+    pub description: String,
+    pub default_branch: Option<String>,
+    pub tag_list: Vec<String>,
+    pub public: bool,
+    pub archived: bool,
+    pub visibility_level: i64,
+    pub ssh_url_to_repo: String,
+    pub http_url_to_repo: String,
+    pub web_url: String,
     // owner: Option<ProjectOwner>,  // FIXME: Why would a project not have an owner?
-    name: String,
-    name_with_namespace: String,
-    path: String,
-    path_with_namespace: String,
-    container_registry_enabled: Option<bool>,
-    issues_enabled: Option<bool>,
-    merge_requests_enabled: Option<bool>,
-    wiki_enabled: Option<bool>,
-    builds_enabled: Option<bool>,
-    snippets_enabled: Option<bool>,
-    created_at: String,  // FIXME: Date instead?
-    last_activity_at: String,  // FIXME: Date instead?
-    shared_runners_enabled: bool,
-    lfs_enabled: bool,
-    creator_id: i64,
-    namespace: ProjectNamespace,
-    forked_from_project: Option<ProjectForkedFrom>,
-    avatar_url: Option<String>,
-    star_count: i64,
-    forks_count: i64,
-    open_issues_count: Option<i64>,
-    runners_token: Option<String>,
-    public_builds: bool,
-    shared_with_groups: Vec<ProjectSharedWithGroup>,
-    only_allow_merge_if_build_succeeds: bool,
-    request_access_enabled: bool,
-    only_allow_merge_if_all_discussions_are_resolved: Option<bool>,  // FIXME: Is bool the proper type?
-    approvals_before_merge: Option<i64>,
-    permissions: Option<ProjectPermissions>,
+    pub name: String,
+    pub name_with_namespace: String,
+    pub path: String,
+    pub path_with_namespace: String,
+    pub container_registry_enabled: Option<bool>,
+    pub issues_enabled: Option<bool>,
+    pub merge_requests_enabled: Option<bool>,
+    pub wiki_enabled: Option<bool>,
+    pub builds_enabled: Option<bool>,
+    pub snippets_enabled: Option<bool>,
+    pub created_at: String,  // FIXME: Date instead?
+    pub last_activity_at: String,  // FIXME: Date instead?
+    pub shared_runners_enabled: bool,
+    pub lfs_enabled: bool,
+    pub creator_id: i64,
+    pub namespace: ProjectNamespace,
+    pub forked_from_project: Option<ProjectForkedFrom>,
+    pub avatar_url: Option<String>,
+    pub star_count: i64,
+    pub forks_count: i64,
+    pub open_issues_count: Option<i64>,
+    pub runners_token: Option<String>,
+    pub public_builds: bool,
+    pub shared_with_groups: Vec<ProjectSharedWithGroup>,
+    pub only_allow_merge_if_build_succeeds: bool,
+    pub request_access_enabled: bool,
+    pub only_allow_merge_if_all_discussions_are_resolved: Option<bool>,  // FIXME: Is bool the proper type?
+    pub approvals_before_merge: Option<i64>,
+    pub permissions: Option<ProjectPermissions>,
 }
 
 pub type Projects = Vec<Project>;
@@ -221,51 +221,51 @@ pub type Projects = Vec<Project>;
 
 
 #[derive(Debug, Serialize, Deserialize)]
-struct Milestone {
-    id: i64,
-    iid: i64,
-    project_id: i64,
-    title: String,
-    description: String,
-    state: MilestoneState,
-    created_at: String,  // FIXME: Use date type?
-    updated_at: String,  // FIXME: Use date type?
-    due_date: Option<String>  // FIXME: Use date type?
+pub struct Milestone {
+    pub id: i64,
+    pub iid: i64,
+    pub project_id: i64,
+    pub title: String,
+    pub description: String,
+    pub state: MilestoneState,
+    pub created_at: String,  // FIXME: Use date type?
+    pub updated_at: String,  // FIXME: Use date type?
+    pub due_date: Option<String>  // FIXME: Use date type?
 }
 
 
 #[derive(Debug, Serialize, Deserialize)]
-struct User {
-    name: String,
-    username: String,
-    id: i64,
-    state: UserState,
-    avatar_url: Option<String>,
-    web_url: Option<String>
+pub struct User {
+    pub name: String,
+    pub username: String,
+    pub id: i64,
+    pub state: UserState,
+    pub avatar_url: Option<String>,
+    pub web_url: Option<String>
 }
 
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Issue {
-    id: i64,
-    iid: i64,
-    project_id: i64,
-    title: String,
-    description: String,
-    state: IssueState,
-    created_at: String,  // FIXME: Use date type?
-    updated_at: String,  // FIXME: Use date type?
-    labels: Vec<String>,
-    milestone: Option<Milestone>,
-    assignee: Option<User>,
-    author: User,
-    subscribed: bool,
-    user_notes_count: i64,
-    upvotes: i64,
-    downvotes: i64,
-    due_date: Option<String>,  // FIXME: Use date type?
-    confidential: bool,
-    web_url: Option<String>
+    pub id: i64,
+    pub iid: i64,
+    pub project_id: i64,
+    pub title: String,
+    pub description: String,
+    pub state: IssueState,
+    pub created_at: String,  // FIXME: Use date type?
+    pub updated_at: String,  // FIXME: Use date type?
+    pub labels: Vec<String>,
+    pub milestone: Option<Milestone>,
+    pub assignee: Option<User>,
+    pub author: User,
+    pub subscribed: bool,
+    pub user_notes_count: i64,
+    pub upvotes: i64,
+    pub downvotes: i64,
+    pub due_date: Option<String>,  // FIXME: Use date type?
+    pub confidential: bool,
+    pub web_url: Option<String>
 }
 
 


### PR DESCRIPTION
The `GitLab` struct is meant as the entry point of all operations.

Until now, it exposes only "low level" functionality by mimicking closely the GitLab API. This makes its cumbersome for the user to query simple things, for example a project's issue using it's `iid` (which cannot be used in GitLab API: it uses the unique `id` instead, which cannot be find simply by a user from the website!)

Also, results returned by GitLab are paginated, so the user needs to iterate over multiple pages manually to find the proper project/issue/merge request/etc.

This MR adds three new "high level" methods:
* `GitLab::get_project(namespace, name)`: Get a specific project from its name and namespace;
* `GitLab::get_issue(namespace, name, iid)`: Get a specific issue from a project and the issue's `iid` (the issue number as seen from the webapp);
* `GitLab::get_merge_request(namespace, name, iid)`: Get a specific merge request from a project and the merge request's `iid` (the issue number as seen from the webapp);